### PR TITLE
Avoid ifdef by using %td printf format

### DIFF
--- a/main/compile_regexes.c
+++ b/main/compile_regexes.c
@@ -82,11 +82,8 @@ static void regex_to_C(const char *name, const cst_regex *rgx)
         printf("NULL, ");
     else
 
-#if defined(_LP64_)
-        printf("%s_rxprog + %ld, ", name, rgx->regmust - rgx->program);
-#else
-        printf("%s_rxprog + %d , ", name, rgx->regmust - rgx->program);
-#endif
+    printf("%s_rxprog + %td, ", name, rgx->regmust - rgx->program);
+
 
     printf("%d, ",rgx->regmlen);
     printf("%d,\n   ",rgx->regsize);


### PR DESCRIPTION
Dear Peter,

Don't think I have abandoned you. :-) I like knowing about bellbird progress so I subscribed to it, and I try to follow your contributions as closer as I can.

I saw you introduced a "#ifdef" for printing a pointer substraction result and I found this "cleaner" solution:

Use %td format for ptrdiff_t data types (see: http://stackoverflow.com/questions/3597743/where-is-ptrdiff-t-defined-in-c )

It's just a tiny commit, but I hope you like it.

Best regards!

PS: By the way, it is amazing the number of format modifiers printf has! http://en.wikipedia.org/wiki/Printf_format_string
